### PR TITLE
Default for billers to be retrieved is 20.

### DIFF
--- a/openapi/paths/utility-payments-get-all-billers.yaml
+++ b/openapi/paths/utility-payments-get-all-billers.yaml
@@ -45,7 +45,7 @@ get:
       name: size
       schema:
         type: integer
-        description: This indicates the number of billers to be retrieved on a page. Default value is 200.
+        description: This indicates the number of billers to be retrieved on a page. Default value is 20.
         example: 10
 
   responses:


### PR DESCRIPTION
The Default value for the billers to be retrieved on a page is 20, not 200.

## What/Why/How?

When I called the API for the billers, I got only 20 by default. but in the documentation, it was given 200. I am very happy to contribute.
